### PR TITLE
Change Apollo Link library to support file or image uploads when needed.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,23 @@
     "test": "jest",
     "ts": "tsc --watch --noEmit --skipLibCheck"
   },
+  "husky": {
+    "hooks": {
+      "pre-commit": "tsc --noEmit --skipLibCheck && lint-staged"
+    }
+  },
+  "lint-staged": {
+    "*.{ts,tsx}": [
+      "yarn run prettier-format",
+      "yarn run lint",
+      "prettier src --write",
+      "git add"
+    ],
+    "*.{json}": [
+      "prettier src --write",
+      "git add"
+    ]
+  },
   "dependencies": {
     "@apollo/react-hoc": "^3.1.2",
     "@react-native-community/async-storage": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "apollo-link": "^1.2.13",
     "apollo-link-context": "^1.0.19",
     "apollo-link-error": "^1.1.12",
-    "apollo-link-http": "^1.5.16",
+    "apollo-upload-client": "^12.1.0",
     "graphql": "^14.5.8",
     "graphql-tag": "^2.10.1",
     "react": "16.9.0",

--- a/src/apollo/index.ts
+++ b/src/apollo/index.ts
@@ -1,15 +1,11 @@
 import { ApolloClient } from 'apollo-client';
 import { InMemoryCache } from 'apollo-cache-inmemory';
-import { HttpLink } from 'apollo-link-http';
 import { setContext } from 'apollo-link-context';
+import { createUploadLink } from 'apollo-upload-client';
 import AsyncStorage from '@react-native-community/async-storage';
 
 import { USER_TOKEN } from '../utils/constant';
 import Config from '../config';
-
-const httpLink = new HttpLink({
-  uri: Config.API_URL,
-});
 
 const authLink = setContext(async (req, { headers }) => {
   const token = await AsyncStorage.getItem(USER_TOKEN);
@@ -22,10 +18,17 @@ const authLink = setContext(async (req, { headers }) => {
   };
 });
 
+const uploadCapableLink = createUploadLink({ uri: Config.API_URL });
+
+export async function renewLink() {
+  client.link = authLink.concat(uploadCapableLink);
+}
+
 const client = new ApolloClient({
-  link: authLink.concat(httpLink),
+  link: authLink.concat(uploadCapableLink),
   cache: new InMemoryCache(),
   connectToDevTools: __DEV__,
+  resolvers: {},
 });
 
 export default client;


### PR DESCRIPTION
Change Apollo Link library to 'apollo-upload-client' to support file or image uploads when needed.